### PR TITLE
bump: version 0.0.0 → 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## v0.1.0 (2024-12-01)
+
+### Feat
+
+- **release**: Add tag based release (#1)
+- **init**: Setup basic necessities for the repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ extend-exclude = '''
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.0"
+version = "0.1.0"
 tag_format = "v$version"
 
 


### PR DESCRIPTION
## v0.1.0 (2024-12-01)

### Feat

- **release**: Add tag based release (#1)
- **init**: Setup basic necessities for the repo